### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/edocuments/backend.py
+++ b/edocuments/backend.py
@@ -139,23 +139,23 @@ class Backend(QObject):
                             print("Add document: " + edocuments.short_path(filename))
                             todo.append((str(filename), cmds, new_date, new_md5.hexdigest()))
                             self.update_library_progress.emit(
-                                0, 'Browsing the files (%i)...' % len(todo), edocuments.short_path(filename))
+                                0, 'Browsing the files ({0:d})...'.format(len(todo)), edocuments.short_path(filename))
 
         self.nb = len(todo)
         self.nb_error = 0
         self.no = 0
 
-        print('Removes %i old documents.' % len(docs_to_rm))
+        print('Removes {0:d} old documents.'.format(len(docs_to_rm)))
 
         with index().index.writer() as writer:
             for num in docs_to_rm:
                 writer.delete_document(num)
 
         self.update_library_progress.emit(
-            0, 'Parsing the files %i/%i.' % (self.no, self.nb), '',
+            0, 'Parsing the files {0:d}/{1:d}.'.format(self.no, self.nb), '',
         )
 
-        print('Process %i documents.' % len(todo))
+        print('Process {0:d} documents.'.format(len(todo)))
 
         with ThreadPoolExecutor(
             max_workers=edocuments.config.get('nb_process', 8)
@@ -173,7 +173,7 @@ class Backend(QObject):
         index().optimize()
 
         if self.nb_error != 0:
-            self.scan_error.emit("Finished with %i errors" % self.nb_error)
+            self.scan_error.emit("Finished with {0:d} errors".format(self.nb_error))
         else:
             self.update_library_progress.emit(
                 100, 'Finish', '',
@@ -192,10 +192,10 @@ class Backend(QObject):
 
             self.no += 1
             self.update_library_progress.emit(
-                self.no * 100 / self.nb, 'Parsing the files %i/%i.' % (self.no, self.nb),
+                self.no * 100 / self.nb, 'Parsing the files {0:d}/{1:d}.'.format(self.no, self.nb),
                 edocuments.short_path(filename),
             )
-            print("%i/%i" % (self.no, self.nb))
+            print("{0:d}/{1:d}".format(self.no, self.nb))
 
             if text is False:
                 print("Error with document: " + filename)
@@ -203,7 +203,7 @@ class Backend(QObject):
             else:
                 index().add(
                     filename,
-                    "%s\n%s" % (filename, text),
+                    "{0!s}\n{1!s}".format(filename, text),
                     date, md5
                 )
 

--- a/edocuments/backend.py
+++ b/edocuments/backend.py
@@ -139,7 +139,10 @@ class Backend(QObject):
                             print("Add document: " + edocuments.short_path(filename))
                             todo.append((str(filename), cmds, new_date, new_md5.hexdigest()))
                             self.update_library_progress.emit(
-                                0, 'Browsing the files ({0:d})...'.format(len(todo)), edocuments.short_path(filename))
+                                0,
+                                'Browsing the files ({0:d})...'.format(len(todo)),
+                                edocuments.short_path(filename),
+                            )
 
         self.nb = len(todo)
         self.nb_error = 0

--- a/edocuments/index.py
+++ b/edocuments/index.py
@@ -47,10 +47,10 @@ class Index:
                 with self.index.writer() as writer:
                     writer.add_field('md5', TEXT(stored=True))
             print(
-                'Field length:\npath: %i\ncontent: %i\nmd5: %i' % (
+                'Field length:\npath: {0:d}\ncontent: {1:d}\nmd5: {2:d}'.format(
                     self.index.field_length("path_id"),
                     self.index.field_length("content"),
-                    self.index.field_length("md5"),
+                    self.index.field_length("md5")
                 )
             )
 

--- a/edocuments/label_dialog.py
+++ b/edocuments/label_dialog.py
@@ -35,7 +35,6 @@ class Dialog(QDialog):
                 button.clicked.connect(action)
                 self.ui.button_container.addWidget(button)
 
-
     def edit(self):
         subprocess.call([self.config.get("edit", "gimp"), self.image])
         self.set_image(self.image)

--- a/test/run
+++ b/test/run
@@ -29,4 +29,4 @@ SCAN_OPTS="--cmds crop normalize cleanup-color normalize auto-rotate --apply"
 simple-run scan-blank1 $SCAN_OPTS
 
 #run scanc-blank --cmds crop normalize cleanup force-cleanup auto-rotate --apply
-#metatask --filename pre-scan-blank.tiff --cmds 
+#metatask --filename pre-scan-blank.tiff --cmds


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:edocuments?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:edocuments?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)